### PR TITLE
[breaking changes] Add credentials and token flags to all subcomands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - name: Test
-        uses: eat-pray-ai/yutu/.github/actions/test@main
+        uses: zamai/yutu/.github/actions/test@main
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6
         env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
-          identifier: eat-pray-ai.yutu
+          identifier: zamai.yutu
           installers-regex: '\.exe$' # Only .exe files
           token: ${{ secrets.RELEASE_PAT }}
           max-versions-to-keep: 3
@@ -81,7 +81,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PAT }}
           tag: ${{ github.event.release.tag_name }}
-          org: eat-pray-ai
+          org: zamai
           formula: yutu
 
   github-package:
@@ -94,6 +94,6 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: eat-pray-ai/yutu/.github/actions/github-packages@main
+      - uses: zamai/yutu/.github/actions/github-packages@main
         with:
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
-      - uses: eat-pray-ai/yutu/.github/actions/test@main
+      - uses: zamai/yutu/.github/actions/test@main

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Download this credential to your local machine with name `client_secret.json`, i
 To verify this credential, run the following command
 
 ```shell
-❯ yutu auth --credentials client_secret.json
+❯ yutu auth --credential client_secret.json
 ```
 
 A browser window will open asking for your permission to access your YouTube account, after granting the permission, a token will be generated and saved to `youtube.token.json`.
@@ -80,7 +80,7 @@ There are two actions available for yutu, one is for general purpose and the oth
 ### Gopher
 
 ```shell
-❯ go install https://github.com/eat-pray-ai/yutu@latest
+❯ go install github.com/eat-pray-ai/yutu@latest
 ```
 
 ### Linux

--- a/cmd/activity/activity.go
+++ b/cmd/activity/activity.go
@@ -15,6 +15,8 @@ var (
 	regionCode      string
 	parts           []string
 	output          string
+	credential      string
+	cacheToken      string
 )
 
 var activityCmd = &cobra.Command{
@@ -28,4 +30,11 @@ var activityCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(activityCmd)
+
+	activityCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	activityCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/activity/list.go
+++ b/cmd/activity/list.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"github.com/eat-pray-ai/yutu/pkg/activity"
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,10 @@ var listCmd = &cobra.Command{
 			activity.WithPublishedAfter(publishedAfter),
 			activity.WithPublishedBefore(publishedBefore),
 			activity.WithRegionCode(regionCode),
-			activity.WithService(nil),
+			activity.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		a.List(parts, output)
 	},

--- a/cmd/caption/caption.go
+++ b/cmd/caption/caption.go
@@ -24,6 +24,8 @@ var (
 	output                 string
 	tfmt                   string
 	tlang                  string
+	credential             string
+	cacheToken             string
 )
 
 var captionCmd = &cobra.Command{
@@ -37,4 +39,11 @@ var captionCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(captionCmd)
+
+	captionCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	captionCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/caption/delete.go
+++ b/cmd/caption/delete.go
@@ -1,6 +1,7 @@
 package caption
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/caption"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +15,10 @@ var deleteCmd = &cobra.Command{
 			caption.WithID(id),
 			caption.WithOnBehalfOf(onBehalfOf),
 			caption.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			caption.WithService(nil),
+			caption.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Delete()
 	},

--- a/cmd/caption/download.go
+++ b/cmd/caption/download.go
@@ -1,6 +1,7 @@
 package caption
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/caption"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var downloadCmd = &cobra.Command{
 			caption.WithTlang(tlang),
 			caption.WithOnBehalfOf(onBehalfOf),
 			caption.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			caption.WithService(nil),
+			caption.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Download()
 	},
@@ -28,7 +32,7 @@ func init() {
 
 	downloadCmd.Flags().StringVarP(&id, "id", "i", "", "ID of the caption")
 	downloadCmd.Flags().StringVarP(&file, "file", "f", "", "Path to save the caption file")
-	downloadCmd.Flags().StringVarP(&tfmt, "tfmt", "t", "", "sbv, srt or vtt")
+	downloadCmd.Flags().StringVarP(&tfmt, "tfmt", "T", "", "sbv, srt or vtt")
 	downloadCmd.Flags().StringVarP(&tlang, "tlang", "l", "", "Translate the captions into this language")
 	downloadCmd.Flags().StringVarP(&onBehalfOf, "onBehalfOf", "b", "", "")
 	downloadCmd.Flags().StringVarP(&onBehalfOfContentOwner, "onBehalfOfContentOwner", "B", "", "")

--- a/cmd/caption/insert.go
+++ b/cmd/caption/insert.go
@@ -1,6 +1,7 @@
 package caption
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/caption"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,10 @@ var insertCmd = &cobra.Command{
 			caption.WithOnBehalfOf(onBehalfOf),
 			caption.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			caption.WithVideoId(videoId),
-			caption.WithService(nil),
+			caption.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Insert(output)
 	},
@@ -55,7 +59,7 @@ func init() {
 	)
 	insertCmd.Flags().StringVarP(&language, "language", "l", "", "Language of the caption track")
 	insertCmd.Flags().StringVarP(&name, "name", "n", "", "Name of the caption track")
-	insertCmd.Flags().StringVarP(&trackKind, "trackKind", "t", "standard", "standard, ASR or forced")
+	insertCmd.Flags().StringVarP(&trackKind, "trackKind", "T", "standard", "standard, ASR or forced")
 	insertCmd.Flags().StringVarP(&videoId, "videoId", "v", "", "ID of the video")
 	insertCmd.Flags().StringVarP(&onBehalfOf, "onBehalfOf", "b", "", "")
 	insertCmd.Flags().StringVarP(&onBehalfOfContentOwner, "onBehalfOfContentOwner", "B", "", "")

--- a/cmd/caption/list.go
+++ b/cmd/caption/list.go
@@ -1,6 +1,7 @@
 package caption
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/caption"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var listCmd = &cobra.Command{
 			caption.WithVideoId(videoId),
 			caption.WithOnBehalfOf(onBehalfOf),
 			caption.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			caption.WithService(nil),
+			caption.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.List(parts, output)
 	},

--- a/cmd/caption/update.go
+++ b/cmd/caption/update.go
@@ -1,6 +1,7 @@
 package caption
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/caption"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,10 @@ var updateCmd = &cobra.Command{
 			caption.WithOnBehalfOf(onBehalfOf),
 			caption.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			caption.WithVideoId(videoId),
-			caption.WithService(nil),
+			caption.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Update(output)
 	},
@@ -55,7 +59,7 @@ func init() {
 	)
 	updateCmd.Flags().StringVarP(&language, "language", "l", "", "Language of the caption track")
 	updateCmd.Flags().StringVarP(&name, "name", "n", "", "Name of the caption track")
-	updateCmd.Flags().StringVarP(&trackKind, "trackKind", "t", "standard", "standard, ASR or forced")
+	updateCmd.Flags().StringVarP(&trackKind, "trackKind", "T", "standard", "standard, ASR or forced")
 	updateCmd.Flags().StringVarP(&videoId, "videoId", "v", "", "ID of the video")
 	updateCmd.Flags().StringVarP(&onBehalfOf, "onBehalfOf", "b", "", "")
 	updateCmd.Flags().StringVarP(&onBehalfOfContentOwner, "onBehalfOfContentOwner", "B", "", "")

--- a/cmd/channel/channel.go
+++ b/cmd/channel/channel.go
@@ -25,6 +25,8 @@ var (
 	title           string
 	output          string
 	parts           []string
+	credential      string
+	cacheToken      string
 )
 
 var channelCmd = &cobra.Command{
@@ -39,13 +41,6 @@ var channelCmd = &cobra.Command{
 func init() {
 	cmd.RootCmd.AddCommand(channelCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// channelCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// channelCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	channelCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	channelCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/channel/list.go
+++ b/cmd/channel/list.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/channel"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,10 @@ var listCmd = &cobra.Command{
 			channel.WithMine(mine, true),
 			channel.WithMySubscribers(mySubscribers, true),
 			channel.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			channel.WithService(nil),
+			channel.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.List(parts, output)
 	},

--- a/cmd/channel/update.go
+++ b/cmd/channel/update.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/channel"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var updateCmd = &cobra.Command{
 			channel.WithDefaultLanguage(defaultLanguage),
 			channel.WithDescription(description),
 			channel.WithTitle(title),
-			channel.WithService(nil),
+			channel.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Update(output)
 	},
@@ -28,7 +32,7 @@ func init() {
 
 	updateCmd.Flags().StringVarP(&id, "id", "i", "", "ID of the channel")
 	updateCmd.Flags().StringVarP(
-		&country, "country", "c", "", "Country of the channel",
+		&country, "country", "C", "", "Country of the channel",
 	)
 	updateCmd.Flags().StringVarP(
 		&customUrl, "customUrl", "u", "", "Custom URL of the channel",
@@ -40,7 +44,7 @@ func init() {
 	updateCmd.Flags().StringVarP(
 		&description, "description", "d", "", "Description of the channel",
 	)
-	updateCmd.Flags().StringVarP(&title, "title", "t", "", "Title of the channel")
+	updateCmd.Flags().StringVarP(&title, "title", "T", "", "Title of the channel")
 	updateCmd.Flags().StringVarP(&output, "output", "o", "", "json, yaml or silent")
 
 	updateCmd.MarkFlagRequired("id")

--- a/cmd/channelBanner/channelBanner.go
+++ b/cmd/channelBanner/channelBanner.go
@@ -6,11 +6,12 @@ import (
 )
 
 var (
-	file   string
-	output string
-
+	file                          string
+	output                        string
 	onBehalfOfContentOwner        string
 	onBehalfOfContentOwnerChannel string
+	credential                    string
+	cacheToken                    string
 )
 
 var channelBannerCmd = &cobra.Command{
@@ -24,4 +25,11 @@ var channelBannerCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(channelBannerCmd)
+
+	channelBannerCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	channelBannerCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/channelBanner/insert.go
+++ b/cmd/channelBanner/insert.go
@@ -1,6 +1,7 @@
 package channelBanner
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/channelBanner"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +15,10 @@ var insertCmd = &cobra.Command{
 			channelBanner.WithFile(file),
 			channelBanner.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			channelBanner.WithOnBehalfOfContentOwnerChannel(onBehalfOfContentOwnerChannel),
-			channelBanner.WithService(nil),
+			channelBanner.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		cb.Insert(output)
 	},

--- a/cmd/channelSection/channelSection.go
+++ b/cmd/channelSection/channelSection.go
@@ -13,6 +13,8 @@ var (
 	onBehalfOfContentOwner string
 	parts                  []string
 	output                 string
+	credential             string
+	cacheToken             string
 )
 
 var channelSectionCmd = &cobra.Command{
@@ -26,4 +28,7 @@ var channelSectionCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(channelSectionCmd)
+
+	channelSectionCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	channelSectionCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/channelSection/delete.go
+++ b/cmd/channelSection/delete.go
@@ -1,6 +1,7 @@
 package channelSection
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/channelSection"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var deleteCmd = &cobra.Command{
 		cs := channelSection.NewChannelSection(
 			channelSection.WithID(id),
 			channelSection.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			channelSection.WithService(nil),
+			channelSection.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		cs.Delete()
 	},

--- a/cmd/channelSection/list.go
+++ b/cmd/channelSection/list.go
@@ -1,6 +1,7 @@
 package channelSection
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/channelSection"
 	"github.com/spf13/cobra"
 )
@@ -11,12 +12,15 @@ var listCmd = &cobra.Command{
 	Long:  "List channel sections",
 	Run: func(cmd *cobra.Command, args []string) {
 		cs := channelSection.NewChannelSection(
+			channelSection.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 			channelSection.WithID(id),
 			channelSection.WithChannelId(channelId),
 			channelSection.WithHl(hl),
 			channelSection.WithMine(mine, true),
 			channelSection.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			channelSection.WithService(nil),
 		)
 		cs.List(parts, output)
 	},

--- a/cmd/comment/comment.go
+++ b/cmd/comment/comment.go
@@ -20,6 +20,8 @@ var (
 	viewerRating     string
 	parts            []string
 	output           string
+	credential       string
+	cacheToken       string
 )
 
 var commentCmd = &cobra.Command{
@@ -33,4 +35,11 @@ var commentCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(commentCmd)
+
+	commentCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	commentCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/comment/delete.go
+++ b/cmd/comment/delete.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,10 @@ var deleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		c := comment.NewComment(
 			comment.WithIDs(ids),
-			comment.WithService(nil),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Delete()
 	},

--- a/cmd/comment/insert.go
+++ b/cmd/comment/insert.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var insertCmd = &cobra.Command{
 			comment.WithParentId(parentId),
 			comment.WithTextOriginal(textOriginal),
 			comment.WithVideoId(videoId),
-			comment.WithService(nil),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Insert(output)
 	},

--- a/cmd/comment/list.go
+++ b/cmd/comment/list.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var listCmd = &cobra.Command{
 			comment.WithMaxResults(maxResults),
 			comment.WithParentId(parentId),
 			comment.WithTextFormat(textFormat),
-			comment.WithService(nil),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.List(parts, output)
 	},

--- a/cmd/comment/markAsSpam.go
+++ b/cmd/comment/markAsSpam.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,10 @@ var markAsSpamCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		c := comment.NewComment(
 			comment.WithIDs(ids),
-			comment.WithService(nil),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.MarkAsSpam(output)
 	},

--- a/cmd/comment/setModerationStatus.go
+++ b/cmd/comment/setModerationStatus.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,10 @@ var setModerationStatusCmd = &cobra.Command{
 			comment.WithIDs(ids),
 			comment.WithModerationStatus(moderationStatus),
 			comment.WithBanAuthor(banAuthor, true),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.SetModerationStatus(output)
 	},

--- a/cmd/comment/update.go
+++ b/cmd/comment/update.go
@@ -1,6 +1,7 @@
 package comment
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/comment"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var updateCmd = &cobra.Command{
 			comment.WithCanRate(canRate, cmd.Flags().Lookup("canRate").Changed),
 			comment.WithTextOriginal(textOriginal),
 			comment.WithViewerRating(viewerRating),
-			comment.WithService(nil),
+			comment.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		c.Update(output)
 	},

--- a/cmd/commentThread/commentThread.go
+++ b/cmd/commentThread/commentThread.go
@@ -19,6 +19,8 @@ var (
 	videoId                      string
 	parts                        []string
 	output                       string
+	credential                   string
+	cacheToken                   string
 )
 
 var commentThreadCmd = &cobra.Command{
@@ -32,4 +34,11 @@ var commentThreadCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(commentThreadCmd)
+
+	commentThreadCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	commentThreadCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/commentThread/insert.go
+++ b/cmd/commentThread/insert.go
@@ -1,6 +1,7 @@
 package commentThread
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/commentThread"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var insertCmd = &cobra.Command{
 			commentThread.WithChannelId(channelId),
 			commentThread.WithTextOriginal(textOriginal),
 			commentThread.WithVideoId(videoId),
-			commentThread.WithService(nil),
+			commentThread.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		ct.Insert(output)
 	},

--- a/cmd/commentThread/list.go
+++ b/cmd/commentThread/list.go
@@ -1,6 +1,7 @@
 package commentThread
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/commentThread"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,10 @@ var listCmd = &cobra.Command{
 			commentThread.WithSearchTerms(searchTerms),
 			commentThread.WithTextFormat(textFormat),
 			commentThread.WithVideoId(videoId),
-			commentThread.WithService(nil),
+			commentThread.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		ct.List(parts, output)
 	},

--- a/cmd/i18nLanguage/i18nLanguage.go
+++ b/cmd/i18nLanguage/i18nLanguage.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	hl     string
-	parts  []string
-	output string
+	hl         string
+	parts      []string
+	output     string
+	credential string
+	cacheToken string
 )
 
 var i18nLanguageCmd = &cobra.Command{
@@ -22,4 +24,11 @@ var i18nLanguageCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(i18nLanguageCmd)
+
+	i18nLanguageCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	i18nLanguageCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/i18nLanguage/list.go
+++ b/cmd/i18nLanguage/list.go
@@ -1,6 +1,7 @@
 package i18nLanguage
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/i18nLanguage"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,11 @@ var listCmd = &cobra.Command{
 	Long:  "List i18nLanguages' id, hl, and name",
 	Run: func(cmd *cobra.Command, args []string) {
 		i := i18nLanguage.NewI18nLanguage(
-			i18nLanguage.WithHl(hl), i18nLanguage.WithService(nil),
+			i18nLanguage.WithHl(hl),
+			i18nLanguage.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		i.List(parts, output)
 	},

--- a/cmd/i18nRegion/i18nRegion.go
+++ b/cmd/i18nRegion/i18nRegion.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	hl     string
-	parts  []string
-	output string
+	hl         string
+	parts      []string
+	output     string
+	credential string
+	cacheToken string
 )
 
 var i18nRegionCmd = &cobra.Command{
@@ -22,4 +24,11 @@ var i18nRegionCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(i18nRegionCmd)
+
+	i18nRegionCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	i18nRegionCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/i18nRegion/list.go
+++ b/cmd/i18nRegion/list.go
@@ -1,6 +1,7 @@
 package i18nRegion
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/i18nRegion"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,11 @@ var listCmd = &cobra.Command{
 	Long:  "List i18nRegions' id, hl, and name",
 	Run: func(cmd *cobra.Command, args []string) {
 		i := i18nRegion.NewI18nRegion(
-			i18nRegion.WithHl(hl), i18nRegion.WithService(nil),
+			i18nRegion.WithHl(hl),
+			i18nRegion.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		i.List(parts, output)
 	},

--- a/cmd/member/list.go
+++ b/cmd/member/list.go
@@ -1,6 +1,7 @@
 package member
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/member"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var listCmd = &cobra.Command{
 			member.WithHasAccessToLevel(hasAccessToLevel),
 			member.WithMaxResults(maxResults),
 			member.WithMode(mode),
-			member.WithService(nil),
+			member.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		m.List(parts, output)
 	},

--- a/cmd/member/member.go
+++ b/cmd/member/member.go
@@ -12,6 +12,8 @@ var (
 	mode             string
 	parts            []string
 	output           string
+	credential       string
+	cacheToken       string
 )
 
 var memberCmd = &cobra.Command{
@@ -25,4 +27,11 @@ var memberCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(memberCmd)
+
+	memberCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	memberCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/membershipsLevel/list.go
+++ b/cmd/membershipsLevel/list.go
@@ -1,6 +1,7 @@
 package membershipsLevel
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/membershipsLevel"
 	"github.com/spf13/cobra"
 )
@@ -10,7 +11,11 @@ var listCmd = &cobra.Command{
 	Short: "List memberships levels",
 	Long:  "List memberships levels' info, such as id, displayName, etc.",
 	Run: func(cmd *cobra.Command, args []string) {
-		m := membershipsLevel.NewMembershipsLevel(membershipsLevel.WithService(nil))
+		m := membershipsLevel.NewMembershipsLevel(
+			membershipsLevel.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)))
 		m.List(parts, output)
 	},
 }

--- a/cmd/membershipsLevel/membershipsLevel.go
+++ b/cmd/membershipsLevel/membershipsLevel.go
@@ -6,8 +6,10 @@ import (
 )
 
 var (
-	parts  []string
-	output string
+	parts      []string
+	output     string
+	credential string
+	cacheToken string
 )
 
 var membershipsLevelCmd = &cobra.Command{
@@ -21,4 +23,11 @@ var membershipsLevelCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(membershipsLevelCmd)
+
+	membershipsLevelCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	membershipsLevelCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/playlist/delete.go
+++ b/cmd/playlist/delete.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlist"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var deleteCmd = &cobra.Command{
 		p := playlist.NewPlaylist(
 			playlist.WithID(id),
 			playlist.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			playlist.WithService(nil),
+			playlist.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		p.Delete()
 	},

--- a/cmd/playlist/insert.go
+++ b/cmd/playlist/insert.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlist"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var insertCmd = &cobra.Command{
 			playlist.WithLanguage(language),
 			playlist.WithChannelId(channelId),
 			playlist.WithPrivacy(privacy),
-			playlist.WithService(nil),
+			playlist.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		p.Insert(output)
 	},

--- a/cmd/playlist/list.go
+++ b/cmd/playlist/list.go
@@ -37,7 +37,7 @@ func init() {
 		"Return the playlists with the given IDs for Stubby or Apiary.",
 	)
 	listCmd.Flags().StringVarP(
-		&channelId, "channelId", "", "",
+		&channelId, "channelId", "C", "",
 		"Return the playlists owned by the specified channel ID",
 	)
 	listCmd.Flags().StringVarP(

--- a/cmd/playlist/list.go
+++ b/cmd/playlist/list.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlist"
 	"github.com/spf13/cobra"
 )
@@ -11,14 +12,18 @@ var listCmd = &cobra.Command{
 	Long:  "List playlist's info, such as title, description, etc.",
 	Run: func(cmd *cobra.Command, args []string) {
 		p := playlist.NewPlaylist(
+			playlist.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 			playlist.WithID(id),
 			playlist.WithChannelId(channelId),
 			playlist.WithHl(hl),
 			playlist.WithMaxResults(maxResults),
+
 			playlist.WithMine(mine, true),
 			playlist.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			playlist.WithOnBehalfOfContentOwnerChannel(onBehalfOfContentOwnerChannel),
-			playlist.WithService(nil),
 		)
 		p.List(parts, output)
 	},
@@ -32,7 +37,7 @@ func init() {
 		"Return the playlists with the given IDs for Stubby or Apiary.",
 	)
 	listCmd.Flags().StringVarP(
-		&channelId, "channelId", "c", "",
+		&channelId, "channelId", "", "",
 		"Return the playlists owned by the specified channel ID",
 	)
 	listCmd.Flags().StringVarP(

--- a/cmd/playlist/playlist.go
+++ b/cmd/playlist/playlist.go
@@ -22,6 +22,8 @@ var (
 
 	onBehalfOfContentOwner        string
 	onBehalfOfContentOwnerChannel string
+	credential                    string
+	cacheToken                    string
 )
 
 var playlistCmd = &cobra.Command{
@@ -35,4 +37,7 @@ var playlistCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(playlistCmd)
+
+	playlistCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	playlistCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/playlist/update.go
+++ b/cmd/playlist/update.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlist"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var updateCmd = &cobra.Command{
 			playlist.WithTags(tags),
 			playlist.WithLanguage(language),
 			playlist.WithPrivacy(privacy),
-			playlist.WithService(nil),
+			playlist.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		p.Update(output)
 	},

--- a/cmd/playlistItem/delete.go
+++ b/cmd/playlistItem/delete.go
@@ -1,6 +1,7 @@
 package playlistItem
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlistItem"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var deleteCmd = &cobra.Command{
 		pi := playlistItem.NewPlaylistItem(
 			playlistItem.WithID(id),
 			playlistItem.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			playlistItem.WithService(nil),
+			playlistItem.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		pi.Delete()
 	},

--- a/cmd/playlistItem/insert.go
+++ b/cmd/playlistItem/insert.go
@@ -1,6 +1,7 @@
 package playlistItem
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlistItem"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,10 @@ var insertCmd = &cobra.Command{
 			playlistItem.WithPrivacy(privacy),
 			playlistItem.WithChannelId(channelId),
 			playlistItem.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			playlistItem.WithService(nil),
+			playlistItem.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		pi.Insert(output)
 	},

--- a/cmd/playlistItem/list.go
+++ b/cmd/playlistItem/list.go
@@ -1,6 +1,7 @@
 package playlistItem
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlistItem"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,10 @@ var listCmd = &cobra.Command{
 			playlistItem.WithMaxResults(maxResults),
 			playlistItem.WithVideoId(videoId),
 			playlistItem.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			playlistItem.WithService(nil),
+			playlistItem.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		pi.List(parts, output)
 	},

--- a/cmd/playlistItem/playlistItem.go
+++ b/cmd/playlistItem/playlistItem.go
@@ -6,21 +6,22 @@ import (
 )
 
 var (
-	id          string
-	title       string
-	description string
-	kind        string
-	kVideoId    string
-	kChannelId  string
-	kPlaylistId string
-	videoId     string
-	playlistId  string
-	channelId   string
-	maxResults  int64
-	privacy     string
-	output      string
-	parts       []string
-
+	id                     string
+	title                  string
+	description            string
+	kind                   string
+	kVideoId               string
+	kChannelId             string
+	kPlaylistId            string
+	videoId                string
+	playlistId             string
+	channelId              string
+	maxResults             int64
+	privacy                string
+	output                 string
+	parts                  []string
+	credential             string
+	cacheToken             string
 	onBehalfOfContentOwner string
 )
 
@@ -35,4 +36,11 @@ var playlistItemCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(playlistItemCmd)
+
+	playlistItemCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	playlistItemCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/playlistItem/update.go
+++ b/cmd/playlistItem/update.go
@@ -1,6 +1,7 @@
 package playlistItem
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/playlistItem"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,10 @@ var updateCmd = &cobra.Command{
 			playlistItem.WithDescription(description),
 			playlistItem.WithPrivacy(privacy),
 			playlistItem.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			playlistItem.WithService(nil),
+			playlistItem.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		pi.Update(output)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "yutu",
 	Short: "A fully functional CLI for YouTube",
-	Long:  "yutu is a fully functional CLI for YouTube, which can be used to manupulate YouTube videos, playlists, channels, etc.",
+	Long:  "yutu is a fully functional CLI for YouTube, which can be used to manipulate YouTube videos, playlists, channels, etc.",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/search/list.go
+++ b/cmd/search/list.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/search"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,10 @@ var listCmd = &cobra.Command{
 	Long:  "List search results",
 	Run: func(cmd *cobra.Command, args []string) {
 		s := search.NewSearch(
+			search.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 			search.WithChannelId(channelId),
 			search.WithChannelType(channelType),
 			search.WithEventType(eventType),
@@ -40,7 +45,6 @@ var listCmd = &cobra.Command{
 			search.WithVideoPaidProductPlacement(videoPaidProductPlacement),
 			search.WithVideoSyndicated(videoSyndicated),
 			search.WithVideoType(videoType),
-			search.WithService(nil),
 		)
 		s.List(parts, output)
 	},

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -37,6 +37,8 @@ var (
 	videoType                 string
 	parts                     []string
 	output                    string
+	credential                string
+	cacheToken                string
 )
 
 var searchCmd = &cobra.Command{
@@ -50,4 +52,7 @@ var searchCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(searchCmd)
+
+	searchCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	searchCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/subscription/delete.go
+++ b/cmd/subscription/delete.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/subscription"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,11 @@ var deleteCmd = &cobra.Command{
 	Long:  "Delete subscription",
 	Run: func(cmd *cobra.Command, args []string) {
 		s := subscription.NewSubscription(
-			subscription.WithID(id), subscription.WithService(nil),
+			subscription.WithID(id),
+			subscription.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		s.Delete()
 	},

--- a/cmd/subscription/insert.go
+++ b/cmd/subscription/insert.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/subscription"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,10 @@ var insertCmd = &cobra.Command{
 			subscription.WithDescription(description),
 			subscription.WithChannelId(channelId),
 			subscription.WithTitle(title),
-			subscription.WithService(nil),
+			subscription.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		s.Insert(output)
 	},

--- a/cmd/subscription/list.go
+++ b/cmd/subscription/list.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/subscription"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,10 @@ var listCmd = &cobra.Command{
 	Long:  "List subscriptions' info, such as id, title, etc.",
 	Run: func(cmd *cobra.Command, args []string) {
 		s := subscription.NewSubscription(
+			subscription.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 			subscription.WithID(id),
 			subscription.WithChannelId(channelId),
 			subscription.WithForChannelId(forChannelId),
@@ -21,7 +26,6 @@ var listCmd = &cobra.Command{
 			subscription.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			subscription.WithOnBehalfOfContentOwnerChannel(onBehalfOfContentOwnerChannel),
 			subscription.WithOrder(order),
-			subscription.WithService(nil),
 		)
 		s.List(parts, output)
 	},

--- a/cmd/subscription/subscription.go
+++ b/cmd/subscription/subscription.go
@@ -21,6 +21,8 @@ var (
 	title                         string
 	parts                         []string
 	output                        string
+	credential                    string
+	cacheToken                    string
 )
 
 var subscriptionCmd = &cobra.Command{
@@ -34,4 +36,7 @@ var subscriptionCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(subscriptionCmd)
+
+	subscriptionCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	subscriptionCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/thumbnail/set.go
+++ b/cmd/thumbnail/set.go
@@ -1,6 +1,7 @@
 package thumbnail
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/thumbnail"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var setCmd = &cobra.Command{
 		t := thumbnail.NewThumbnail(
 			thumbnail.WithFile(file),
 			thumbnail.WithVideoId(videoId),
-			thumbnail.WithService(nil),
+			thumbnail.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		t.Set(output)
 	},

--- a/cmd/thumbnail/thumbnail.go
+++ b/cmd/thumbnail/thumbnail.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	file    string
-	videoId string
-	output  string
+	file       string
+	videoId    string
+	output     string
+	credential string
+	cacheToken string
 )
 
 var thumbnailCmd = &cobra.Command{
@@ -22,4 +24,11 @@ var thumbnailCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(thumbnailCmd)
+
+	thumbnailCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	thumbnailCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/video/delete.go
+++ b/cmd/video/delete.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -10,7 +11,13 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete a video on Youtube",
 	Long:  "Delete a video on Youtube",
 	Run: func(cmd *cobra.Command, args []string) {
-		v := video.NewVideo(video.WithID(id))
+		v := video.NewVideo(
+			video.WithID(id),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
+		)
 		v.Delete()
 	},
 }

--- a/cmd/video/getRating.go
+++ b/cmd/video/getRating.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var getRatingCmd = &cobra.Command{
 		v := video.NewVideo(
 			video.WithID(id),
 			video.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			video.WithService(nil),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		v.GetRating()
 	},

--- a/cmd/video/insert.go
+++ b/cmd/video/insert.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,10 @@ var insertCmd = &cobra.Command{
 			video.WithPublicStatsViewable(publicStatsViewable),
 			video.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			video.WithOnBehalfOfContentOwnerChannel(onBehalfOfContentOwnerChannel),
-			video.WithService(nil),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		v.Insert(output)
 	},

--- a/cmd/video/list.go
+++ b/cmd/video/list.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,10 @@ var listCmd = &cobra.Command{
 	Long:  "List video's info, such as title, description, etc.",
 	Run: func(cmd *cobra.Command, args []string) {
 		v := video.NewVideo(
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 			video.WithID(id),
 			video.WithChart(chart),
 			video.WithHl(hl),
@@ -22,7 +27,6 @@ var listCmd = &cobra.Command{
 			video.WithMaxResults(maxResults),
 			video.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
 			video.WithRating(rating),
-			video.WithService(nil),
 		)
 		v.List(parts, output)
 	},

--- a/cmd/video/rate.go
+++ b/cmd/video/rate.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,10 @@ var rateCmd = &cobra.Command{
 		v := video.NewVideo(
 			video.WithID(id),
 			video.WithRating(rating),
-			video.WithService(nil),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		v.Rate()
 	},

--- a/cmd/video/reportAbuse.go
+++ b/cmd/video/reportAbuse.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ var reportAbuseCmd = &cobra.Command{
 			video.WithComments(comments),
 			video.WithLanguage(language),
 			video.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			video.WithService(nil),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		v.ReportAbuse()
 	},

--- a/cmd/video/update.go
+++ b/cmd/video/update.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/video"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +23,10 @@ var updateCmd = &cobra.Command{
 			video.WithCategory(categoryId),
 			video.WithPrivacy(privacy),
 			video.WithEmbeddable(embeddable),
-			video.WithService(nil),
+			video.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		v.Update(output)
 	},

--- a/cmd/video/video.go
+++ b/cmd/video/video.go
@@ -42,6 +42,8 @@ var (
 	publicStatsViewable           bool
 	onBehalfOfContentOwner        string
 	onBehalfOfContentOwnerChannel string
+	credential                    string
+	cacheToken                    string
 )
 
 // videoCmd represents the video command
@@ -57,13 +59,6 @@ var videoCmd = &cobra.Command{
 func init() {
 	cmd.RootCmd.AddCommand(videoCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// videoCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// videoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	videoCmd.PersistentFlags().StringVarP(&credential, "credential", "c", "client_secret.json", "Path to client secret file")
+	videoCmd.PersistentFlags().StringVarP(&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file")
 }

--- a/cmd/videoAbuseReportReason/list.go
+++ b/cmd/videoAbuseReportReason/list.go
@@ -1,6 +1,7 @@
 package videoAbuseReportReason
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/videoAbuseReportReason"
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,10 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		va := videoAbuseReportReason.NewVideoAbuseReportReason(
 			videoAbuseReportReason.WithHL(hl),
-			videoAbuseReportReason.WithService(nil),
+			videoAbuseReportReason.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		va.List(parts, output)
 	},

--- a/cmd/videoAbuseReportReason/videoAbuseReportReason.go
+++ b/cmd/videoAbuseReportReason/videoAbuseReportReason.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	hl     string
-	parts  []string
-	output string
+	hl         string
+	parts      []string
+	output     string
+	credential string
+	cacheToken string
 )
 
 var videoAbuseReportReasonCmd = &cobra.Command{
@@ -22,4 +24,11 @@ var videoAbuseReportReasonCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(videoAbuseReportReasonCmd)
+
+	videoAbuseReportReasonCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	videoAbuseReportReasonCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/videoCategory/list.go
+++ b/cmd/videoCategory/list.go
@@ -1,6 +1,7 @@
 package videoCategory
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/videoCategory"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +15,10 @@ var listCmd = &cobra.Command{
 			videoCategory.WithID(id),
 			videoCategory.WithHl(hl),
 			videoCategory.WithRegionCode(regionCode),
-			videoCategory.WithService(nil),
+			videoCategory.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		vc.List(parts, output)
 	},

--- a/cmd/videoCategory/videoCategory.go
+++ b/cmd/videoCategory/videoCategory.go
@@ -11,6 +11,8 @@ var (
 	regionCode string
 	parts      []string
 	output     string
+	credential string
+	cacheToken string
 )
 
 var videoCategoryCmd = &cobra.Command{
@@ -24,4 +26,11 @@ var videoCategoryCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(videoCategoryCmd)
+
+	videoCategoryCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	videoCategoryCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }

--- a/cmd/watermark/set.go
+++ b/cmd/watermark/set.go
@@ -1,6 +1,7 @@
 package watermark
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/watermark"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,10 @@ var setCmd = &cobra.Command{
 			watermark.WithOffsetMs(offsetMs),
 			watermark.WithOffsetType(offsetType),
 			watermark.WithOnBehalfOfContentOwner(onBehalfOfContentOwner),
-			watermark.WithService(nil),
+			watermark.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		w.Set()
 	},

--- a/cmd/watermark/unset.go
+++ b/cmd/watermark/unset.go
@@ -1,6 +1,7 @@
 package watermark
 
 import (
+	"github.com/eat-pray-ai/yutu/pkg/auth"
 	"github.com/eat-pray-ai/yutu/pkg/watermark"
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,10 @@ var unsetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		w := watermark.NewWatermark(
 			watermark.WithChannelId(channelId),
-			watermark.WithService(nil),
+			watermark.WithService(auth.NewY2BService(
+				auth.WithCredential(credential),
+				auth.WithCacheToken(cacheToken),
+			)),
 		)
 		w.Unset()
 	},

--- a/cmd/watermark/watermark.go
+++ b/cmd/watermark/watermark.go
@@ -13,6 +13,8 @@ var (
 	offsetMs               uint64
 	offsetType             string
 	onBehalfOfContentOwner string
+	credential             string
+	cacheToken             string
 )
 
 var wartermarkCmd = &cobra.Command{
@@ -26,4 +28,11 @@ var wartermarkCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(wartermarkCmd)
+
+	wartermarkCmd.PersistentFlags().StringVarP(
+		&credential, "credential", "c", "client_secret.json", "Path to client secret file",
+	)
+	wartermarkCmd.PersistentFlags().StringVarP(
+		&cacheToken, "cacheToken", "t", "youtube.token.json", "Path to token cache file",
+	)
 }


### PR DESCRIPTION
Hi, nice project, I used it to upload videos via bash script.

I noticed that credentials and token flags where only working inside the Auth command, and rest of the sub commands relied on the hardcoded path of the `client_secret.json` - which is same folder as binary execution. Which does not really work for me, so I added these flags to all subcommands (not sure if it's the correct implementation, first coding with cobra). 

There are several subcommands that have the same shortcut `t` or `c` , so I replaced them with uppercase letters - which would a breaking change for users. 

Not sure if you want to merge this PR as is, or just take it's implementation as starting point for next version, just thought it might be worth sharing my patch. 

🙏