### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # `yutu`
 
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.eat-pray-ai%2Fyutu.svg)](https://mcptoplist.com/server/io.github.eat-pray-ai%2Fyutu)
+
 [![Static Badge](https://img.shields.io/badge/gitmoji-%F0%9F%98%BF%F0%9F%90%B0%F0%9F%90%A7%E2%9D%A4%EF%B8%8F%E2%80%8D%F0%9F%A9%B9-love?style=flat-square&labelColor=%23EDD1CC&color=%23FF919F)](https://gitmoji.dev)
 [![GitHub License](https://img.shields.io/github/license/eat-pray-ai/yutu?style=flat-square)](https://github.com/eat-pray-ai/yutu?tab=Apache-2.0-1-ov-file)
 [![Go Reference](https://pkg.go.dev/badge/github.com/eat-pray-ai/yutu?style=flat-square)](https://pkg.go.dev/github.com/eat-pray-ai/yutu)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **yutu** is currently ranked **#357**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.eat-pray-ai%2Fyutu.svg)](https://mcptoplist.com/server/io.github.eat-pray-ai%2Fyutu)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building yutu!
