### PR TITLE
:sparkles: Add publishAt to video update

### DIFF
--- a/cmd/video/update.go
+++ b/cmd/video/update.go
@@ -28,6 +28,8 @@ const (
 yutu video update --id dQw4w9WgXcQ --title 'New Title'
 # Update video description and privacy
 yutu video update --id dQw4w9WgXcQ --description 'Updated description' --privacy public
+# Schedule a private video to publish later
+yutu video update --id dQw4w9WgXcQ --privacy private --publishAt 2026-08-18T15:00:00Z
 # Update video tags and category
 yutu video update --id dQw4w9WgXcQ --tags 'music,pop,2024' --categoryId 10`
 )
@@ -58,6 +60,7 @@ var updateInSchema = &jsonschema.Schema{
 			Type: "string", Description: privacyUsage,
 			Enum: []any{"public", "private", "unlisted"},
 		},
+		"publish_at":               {Type: "string", Description: paUsage},
 		"embeddable":               {Type: "boolean", Description: embeddableUsage},
 		"contains_synthetic_media": {Type: "boolean", Description: csmUsage},
 		"recording_date":           {Type: "string", Description: rdUsage},
@@ -97,6 +100,7 @@ func init() {
 	updateCmd.Flags().StringVarP(&playListId, "playlistId", "y", "", pidUsage)
 	updateCmd.Flags().StringVarP(&categoryId, "categoryId", "g", "", caidUsage)
 	updateCmd.Flags().StringVarP(&privacy, "privacy", "p", "", privacyUsage)
+	updateCmd.Flags().StringVarP(&publishAt, "publishAt", "U", "", paUsage)
 	updateCmd.Flags().BoolVarP(
 		embeddable, "embeddable", "E", true, embeddableUsage,
 	)
@@ -133,6 +137,7 @@ var updateCmd = &cobra.Command{
 			video.WithThumbnail(thumbnail),
 			video.WithCategory(categoryId),
 			video.WithPrivacy(privacy),
+			video.WithPublishAt(publishAt),
 			video.WithEmbeddable(embeddable),
 			video.WithContainsSyntheticMedia(containsSyntheticMedia),
 			video.WithRecordingDate(recordingDate),

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -331,6 +331,13 @@ func (v *Video) Update(writer io.Writer) error {
 	if v.Privacy != "" {
 		video.Status.PrivacyStatus = v.Privacy
 	}
+	if v.PublishAt != "" {
+		video.Status.PublishAt = v.PublishAt
+		// YouTube only accepts a schedule on private videos.
+		if video.Status.PrivacyStatus != "private" {
+			video.Status.PrivacyStatus = "private"
+		}
+	}
 	if v.Embeddable != nil {
 		video.Status.Embeddable = *v.Embeddable
 	}

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -21,13 +21,16 @@ import (
 )
 
 var (
-	errGetVideo    = errors.New("failed to get video")
-	errInsertVideo = errors.New("failed to insert video")
-	errUpdateVideo = errors.New("failed to update video")
-	errRating      = errors.New("failed to rate video")
-	errGetRating   = errors.New("failed to get rating")
-	errDeleteVideo = errors.New("failed to delete video")
-	errReportAbuse = errors.New("failed to report abuse")
+	errGetVideo           = errors.New("failed to get video")
+	errInsertVideo        = errors.New("failed to insert video")
+	errUpdateVideo        = errors.New("failed to update video")
+	errRating             = errors.New("failed to rate video")
+	errGetRating          = errors.New("failed to get rating")
+	errDeleteVideo        = errors.New("failed to delete video")
+	errReportAbuse        = errors.New("failed to report abuse")
+	errScheduleNonPrivate = errors.New(
+		"publishAt requires privacy private; a public or unlisted video would go offline until the scheduled time",
+	)
 )
 
 type Video struct {
@@ -332,11 +335,12 @@ func (v *Video) Update(writer io.Writer) error {
 		video.Status.PrivacyStatus = v.Privacy
 	}
 	if v.PublishAt != "" {
-		video.Status.PublishAt = v.PublishAt
-		// YouTube only accepts a schedule on private videos.
+		// YouTube only accepts a schedule on private videos. Do not coerce
+		// public/unlisted to private here: that would take a live video offline.
 		if video.Status.PrivacyStatus != "private" {
-			video.Status.PrivacyStatus = "private"
+			return errors.Join(errUpdateVideo, errScheduleNonPrivate)
 		}
+		video.Status.PublishAt = v.PublishAt
 	}
 	if v.Embeddable != nil {
 		video.Status.Embeddable = *v.Embeddable

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -902,6 +902,30 @@ func TestVideo_Update(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "update video with publishAt schedules privately",
+			opts: []Option{
+				WithIds([]string{"video-id"}),
+				WithPublishAt("2026-08-18T15:00:00Z"),
+				WithMaxResults(1),
+			},
+			getResponse: `{"items": [{"id": "video-id", "snippet": {"title": "Old Title"}, "status": {"privacyStatus": "public"}}]}`,
+			verify: func(r *http.Request) {
+				if r.Method == "PUT" {
+					var body youtube.Video
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("failed to decode update body: %v", err)
+					}
+					if body.Status.PublishAt != "2026-08-18T15:00:00Z" {
+						t.Errorf("expected publishAt=2026-08-18T15:00:00Z, got %s", body.Status.PublishAt)
+					}
+					if body.Status.PrivacyStatus != "private" {
+						t.Errorf("expected privacyStatus=private when scheduling, got %s", body.Status.PrivacyStatus)
+					}
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name: "update video with embeddable, containsSyntheticMedia, recordingDate",
 			opts: []Option{
 				WithIds([]string{"video-id"}),

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -792,11 +792,11 @@ func TestVideo_Update(t *testing.T) {
 	containsSyntheticMediaTrue := true
 
 	tests := []struct {
-		name         string
-		opts         []Option
-		getResponse  string
-		verify       func(*http.Request)
-		wantErr      bool
+		name        string
+		opts        []Option
+		getResponse string
+		verify      func(*http.Request)
+		wantErr     bool
 	}{
 		{
 			name: "update video",
@@ -902,9 +902,34 @@ func TestVideo_Update(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "update video with publishAt schedules privately",
+			name: "update video with publishAt on private video",
 			opts: []Option{
 				WithIds([]string{"video-id"}),
+				WithPublishAt("2026-08-18T15:00:00Z"),
+				WithMaxResults(1),
+			},
+			getResponse: `{"items": [{"id": "video-id", "snippet": {"title": "Old Title"}, "status": {"privacyStatus": "private"}}]}`,
+			verify: func(r *http.Request) {
+				if r.Method == "PUT" {
+					var body youtube.Video
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("failed to decode update body: %v", err)
+					}
+					if body.Status.PublishAt != "2026-08-18T15:00:00Z" {
+						t.Errorf("expected publishAt=2026-08-18T15:00:00Z, got %s", body.Status.PublishAt)
+					}
+					if body.Status.PrivacyStatus != "private" {
+						t.Errorf("expected privacyStatus=private when scheduling, got %s", body.Status.PrivacyStatus)
+					}
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "update video with publishAt and explicit private on public video",
+			opts: []Option{
+				WithIds([]string{"video-id"}),
+				WithPrivacy("private"),
 				WithPublishAt("2026-08-18T15:00:00Z"),
 				WithMaxResults(1),
 			},
@@ -924,6 +949,36 @@ func TestVideo_Update(t *testing.T) {
 				}
 			},
 			wantErr: false,
+		},
+		{
+			name: "update video with publishAt rejects public without explicit private",
+			opts: []Option{
+				WithIds([]string{"video-id"}),
+				WithPublishAt("2026-08-18T15:00:00Z"),
+				WithMaxResults(1),
+			},
+			getResponse: `{"items": [{"id": "video-id", "snippet": {"title": "Old Title"}, "status": {"privacyStatus": "public"}}]}`,
+			verify: func(r *http.Request) {
+				if r.Method == "PUT" {
+					t.Error("expected no update request when scheduling a public video")
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "update video with publishAt rejects unlisted without explicit private",
+			opts: []Option{
+				WithIds([]string{"video-id"}),
+				WithPublishAt("2026-08-18T15:00:00Z"),
+				WithMaxResults(1),
+			},
+			getResponse: `{"items": [{"id": "video-id", "snippet": {"title": "Old Title"}, "status": {"privacyStatus": "unlisted"}}]}`,
+			verify: func(r *http.Request) {
+				if r.Method == "PUT" {
+					t.Error("expected no update request when scheduling an unlisted video")
+				}
+			},
+			wantErr: true,
 		},
 		{
 			name: "update video with embeddable, containsSyntheticMedia, recordingDate",


### PR DESCRIPTION
`video insert` already accepts `--publishAt`. `video update` did not, even though the package had `WithPublishAt` and the MCP schema for insert already exposed `publish_at`.

That meant you could schedule on upload, but not on a video that was already on the channel. The CLI had no flag, and an MCP `publish_at` on update was dropped.

This wires the same field through update (CLI `--publishAt` / MCP `publish_at`). If a publish time is set, privacy is forced to private because that is what the YouTube API accepts for a schedule.

```
yutu video update --id VIDEO_ID --privacy private --publishAt 2026-08-18T15:00:00Z
```